### PR TITLE
Change expense reporting categorization

### DIFF
--- a/output_generation.py
+++ b/output_generation.py
@@ -13,7 +13,8 @@ def generate_csv_outputs(self):
     self.Acct_Level_Summary.to_excel(writer, sheet_name='Account')
     self.Revenue_Trend_primary_cat.to_excel(writer, sheet_name='Revenue_Trend_primary_cat')
     self.Revenue_Trend_secondary_cat.to_excel(writer, sheet_name='Revenue_Trend_secondary_cat')
-    self.Expense_Pivot.to_excel(writer,sheet_name='Expenses_Trend')
+    self.Expense_Trend_primary_cat.to_excel(writer, sheet_name='Expense_Trend_primary_cat')
+    self.Expense_Trend_secondary_cat.to_excel(writer, sheet_name='Expense_Trend_secondary_cat')
     self.Summary_KPI.to_excel(writer,sheet_name='Summary_KPI')
     self.securities.to_excel(writer, sheet_name='Security_valuations')
 

--- a/run_qc_tests.py
+++ b/run_qc_tests.py
@@ -29,7 +29,7 @@ def ensure_no_non_standard_account_names(self):
 
     Non_standard_acc_names = len(self.Transactions_temp_2[(self.Transactions_temp_2["Impacted_Acc_ID_1"].isnull()) | (self.Transactions_temp_2["Impacted_Acc_2"].isnull())])
     Non_standard_rev_names = len(self.transactions_with_income_IDs[self.transactions_with_income_IDs["inc_grp_ID"].isnull()])
-    Non_standard_exp_names = len(self.Expenses_Subset[self.Expenses_Subset["exp_grp_ID"].isnull()])
+    Non_standard_exp_names = len(self.transactions_with_expense_IDs[self.transactions_with_expense_IDs["exp_grp_ID"].isnull()])
 
     if Non_standard_acc_names + Non_standard_rev_names + Non_standard_exp_names > 0:
         print("(3) ❌ Non-standard account names detected")


### PR DESCRIPTION
This PR was created to change the way expense line items are reported in the expense report (in order to improve performance reporting). The new way still breaks down the expense line items by period (month / year), but the line items are now presented as either:
(1) Primary expense category (for example, Living Expense - Opex), and/or
(2) Secondary expense category (for example, Utilities Expense)