### PR TITLE
Combine revenue & expense reporting modules into 1 P&L module

### DIFF
--- a/income_statement_calculations.py
+++ b/income_statement_calculations.py
@@ -4,78 +4,62 @@
 import pandas as pd
 import numpy as np
 
-def get_revenue_trend(self):
+def generate_profit_and_loss_statement(self):
 
-    """This block of code determines the revenue by period (by month and year)"""
+    """This block of code determines the profit & loss (P&L) by period (by month and year)"""
 
-    # (1) Filter to only transactions data that has revenue recognition
+    columns_to_keep = ["Tr_Year", "Tr_Month", "P_L_primary_cat", "P_L_secondary_cat", "P_L_secondary_cat_after_offset", "P_L_offset_flag", "tr_amt"]
+
+    # (1) Filter to only transactions data that has revenue and/or expense recognition
     transactions_with_revenue_recognition = self.Transactions[~self.Transactions["tr_income"].isnull()]
-    self.transactions_with_income_IDs = transactions_with_revenue_recognition.merge(self.Income_Picklist, left_on=["tr_income"], right_on=["inc_name"], how='left').merge(self.Income_Group_Picklist, on='inc_grp_ID', how='left')
-
-    # (2) Exclude revenue sources coming from:
-    # (a) Insurance Reimbursement (these will later be presented as offsets to total healthcare costs in the expense report)
-    # (b) Proceeds from sale of assets (the gains / losses are currently inserted manually into the transactions table)
-    subset = self.transactions_with_income_IDs[~self.transactions_with_income_IDs["inc_secondary_cat"].isna()]
-
-    # (3) Group the different revenue sources by period
-    time_trend = subset.groupby(["Tr_Year", "Tr_Month", "inc_primary_cat", "inc_secondary_cat"],as_index=False)["tr_amt"].sum()
-
-    # (4) Add the total
-    agg_trend = subset.groupby(["Tr_Year", "Tr_Month"],as_index=False)["tr_amt"].sum()
-    agg_trend["inc_primary_cat"] = '(0) Total'
-    agg_trend["inc_secondary_cat"] = '(0) Total'
-
-    time_trend_with_totals = time_trend.append(agg_trend)
-
-    # (5) Create pivot table summaries (one based on the primary category, and the other based on the secondary category)
-    self.Revenue_Trend_primary_cat = pd.pivot_table(time_trend_with_totals,
-                                                    index=['Tr_Year', 'Tr_Month'],
-                                                    values=['tr_amt'],
-                                                    columns=['inc_primary_cat'],
-                                                    aggfunc=[np.sum])
-    self.Revenue_Trend_secondary_cat = pd.pivot_table(time_trend_with_totals,
-                                                      index=['Tr_Year', 'Tr_Month'],
-                                                      values=['tr_amt'],
-                                                      columns=['inc_primary_cat', 'inc_secondary_cat'],
-                                                      aggfunc=[np.sum])
-
-    print('finished generating breakdown of revenue by month and year')
-
-def get_expenses_trend(self):
-
-    """This block of code determines the expenses by period (by month and year)"""
-
-    # (1) Filter to only transactions data that has expense recognition
     transactions_with_expense_recognition = self.Transactions[~self.Transactions["tr_expense"].isnull()]
-    self.transactions_with_expense_IDs = transactions_with_expense_recognition.merge(self.Expense_Picklist,left_on=["tr_expense"],right_on=["exp_name"],how='left').merge(self.Expense_Group_Picklist,on=['exp_grp_ID'],how='left')
 
-    # (2) Exclude expense sources coming from:
-    # (a) Depreciation expenses
-    # (b) Purchases of securities
-    subset = self.transactions_with_expense_IDs[~self.transactions_with_expense_IDs["exp_primary_cat"].isna()]
+    # (2) Add the P&L IDs
+    self.transactions_with_income_IDs = transactions_with_revenue_recognition.merge(self.Income_Picklist, left_on=["tr_income"], right_on=["inc_name"], how='left').merge(self.Income_Group_Picklist, on='inc_grp_ID', how='left')
+    self.transactions_with_expense_IDs = transactions_with_expense_recognition.merge(self.Expense_Picklist, left_on=["tr_expense"], right_on=["exp_name"], how='left').merge(self.Expense_Group_Picklist, on=['exp_grp_ID'], how='left')
 
-    # (3) Group the different expense sources by period
-    time_trend = subset.groupby(['exp_primary_cat','exp_secondary_cat','Tr_Year','Tr_Month'],as_index=False)['tr_amt'].sum()
+    # (3) Include only transactions with non-NULL P&L IDs:
+    # Exclude certain expenses (like depreciation and acquisition of shares) and revenues (like proceeds from sales of shares)
+    subset_income = self.transactions_with_income_IDs[~self.transactions_with_income_IDs["P_L_primary_cat"].isna()]
+    subset_expenses = self.transactions_with_expense_IDs[~self.transactions_with_expense_IDs["P_L_primary_cat"].isna()]
 
-    # (4) Add the total (ONLY for living expenses)
-    agg_trend = subset[subset['exp_primary_cat'].isin(["(1) Living (Opex)", "(2) Living (Capex)"])].groupby(["Tr_Year", "Tr_Month"], as_index=False)["tr_amt"].sum()
-    agg_trend["exp_primary_cat"] = '(0) Total Living'
-    agg_trend["exp_secondary_cat"] = '(0) Total Living'
-    time_trend_with_totals = time_trend.append(agg_trend)
+    # (4) Keep only the required columns
+    subset_income = subset_income[columns_to_keep]
+    subset_expenses = subset_expenses[columns_to_keep]
 
-    # (4) Create pivot table summaries (one based on the primary category, and the other based on the secondary category)
-    self.Expense_Trend_primary_cat = pd.pivot_table(time_trend_with_totals,
-                                                    index=['Tr_Year','Tr_Month'],
-                                                    values=['tr_amt'],
-                                                    columns=['exp_primary_cat'],
-                                                    aggfunc=[np.sum])
-    self.Expense_Trend_secondary_cat = pd.pivot_table(time_trend_with_totals,
-                                                      index=['Tr_Year', 'Tr_Month'],
-                                                      values=['tr_amt'],
-                                                      columns=['exp_primary_cat', 'exp_secondary_cat'],
-                                                      aggfunc=[np.sum])
+    # (5) Assign the magnitudes (+1 for income and -1 for expense)
+    subset_income['amount'] = subset_income['tr_amt'] * 1
+    subset_expenses['amount'] = subset_expenses['tr_amt'] * -1
 
-    print('finished generating breakdown of expenses by month and year')
+    # (6) Determine the transaction type
+    subset_income['type'] = '(1) revenue'
+    subset_expenses['type'] = '(2) expenses'
+    # Those with offsets need to change transaction type (for example, healthcare insurance reimbursements should be classified as an offset to the healthcare expense instead of a revenue line item)
+    subset_income.loc[subset_income['P_L_offset_flag']==1, 'type'] = '(2) expenses'
+    subset_expenses.loc[subset_expenses['P_L_offset_flag'] == 1, 'type'] = '(1) revenue'
+
+    # (6) Append the revenue and expense statements together
+    subset = subset_income.append(subset_expenses, ignore_index=True)
+
+    # (7) Get the remapped secondary P&L category
+    subset.loc[subset["P_L_secondary_cat_after_offset"].isna(), "P_L_secondary_cat_after_offset"] = subset["P_L_secondary_cat"]
+
+    # (8) Group the line items by period
+    time_trend = subset.groupby(["Tr_Year", "Tr_Month", "type", "P_L_primary_cat", "P_L_secondary_cat", "P_L_secondary_cat_after_offset"], as_index=False)["amount"].sum()
+
+    # (9) Create pivot table summaries (one based on a higher-level, and the other based on a deep dive)
+    self.P_L_statement_overall = pd.pivot_table(time_trend,
+                                                index=['type', 'P_L_primary_cat', 'P_L_secondary_cat_after_offset'],
+                                                columns=['Tr_Year', 'Tr_Month'],
+                                                values=['amount'],
+                                                aggfunc=[np.sum])
+    self.P_L_statement_deep_dive = pd.pivot_table(time_trend,
+                                                  index=['type', 'P_L_primary_cat', 'P_L_secondary_cat'],
+                                                  columns=['Tr_Year', 'Tr_Month'],
+                                                  values=['amount'],
+                                                  aggfunc=[np.sum])
+
+    print('finished generating breakdown of P&L statement by month and year')
 
 def calculate_financial_KPIs(self):
 

--- a/main_script.py
+++ b/main_script.py
@@ -16,7 +16,7 @@ import pandas as pd
 from data_ingestion import ingestion_pipeline
 from security_valuation import get_quantities_on_closing_date, get_market_values_on_closing_date
 from balance_sheet_calculations import get_account_level_balance_sheet, get_account_type_level_balance_sheet, get_overall_balance_sheet
-from income_statement_calculations import get_revenue_trend, get_expenses_trend, calculate_financial_KPIs
+from income_statement_calculations import calculate_financial_KPIs, generate_profit_and_loss_statement
 from run_qc_tests import verify_accounting_equation, ensure_closing_date_is_later_than_initiation_dates, ensure_no_non_standard_account_names
 from output_generation import generate_csv_outputs
 
@@ -70,9 +70,8 @@ def main():
     get_account_type_level_balance_sheet(datasets)
     get_overall_balance_sheet(datasets)
 
-    # (d) Get revenue and expense trends
-    get_revenue_trend(datasets)
-    get_expenses_trend(datasets)
+    # (d) Get income statement by period
+    generate_profit_and_loss_statement(datasets)
 
     # (e) Ratio calculations
     calculate_financial_KPIs(datasets)

--- a/output_generation.py
+++ b/output_generation.py
@@ -11,10 +11,8 @@ def generate_csv_outputs(self):
     self.BS_Level_Summary.to_excel(writer, sheet_name='Overall')
     self.Class_Level_Summary.to_excel(writer, sheet_name='Class')
     self.Acct_Level_Summary.to_excel(writer, sheet_name='Account')
-    self.Revenue_Trend_primary_cat.to_excel(writer, sheet_name='Revenue_Trend_primary_cat')
-    self.Revenue_Trend_secondary_cat.to_excel(writer, sheet_name='Revenue_Trend_secondary_cat')
-    self.Expense_Trend_primary_cat.to_excel(writer, sheet_name='Expense_Trend_primary_cat')
-    self.Expense_Trend_secondary_cat.to_excel(writer, sheet_name='Expense_Trend_secondary_cat')
+    self.P_L_statement_overall.to_excel(writer, sheet_name='monthly_P_L_overall')
+    self.P_L_statement_deep_dive.to_excel(writer, sheet_name='monthly_P_L_deep_dive')
     self.Summary_KPI.to_excel(writer,sheet_name='Summary_KPI')
     self.securities.to_excel(writer, sheet_name='Security_valuations')
 


### PR DESCRIPTION
This PR was created in order to combine the revenue & expense reporting modules into 1 P&L module. This integration also makes it easier to introduce the line-item offset concept that makes performance review and analysis more insightful. These include sources of expenses and/or revenues that are closely coupled to one another, such as:
(1) Representing healthcare insurance reimbursements as an offset to healthcare costs, instead of as its own line item in the revenue report
(2) Representing work-related expenses (like income taxes) as an offset to the employment revenue (like salary), instead of its own line item in the expense report

When viewed separately, these line-items provide little context because they need to be scaled up to their countering line-item (for example, insurance reimbursement is a % of the incidence cost, and taxes is a % of salary). Therefore, netting them together provides far richer context.