### PR TITLE
Reindex Acct_Level_Summary prior to uploading to GBQ

### DIFF
--- a/output_generation.py
+++ b/output_generation.py
@@ -25,6 +25,7 @@ def output_upload_to_cloud(self):
 
     # (1) Set the publish date for the balance sheet dataset
     self.Acct_Level_Summary['publish_date'] = self.end_date
+    self.Acct_Level_Summary.reset_index(drop=True, inplace=True)
 
     # (2) Upload to BigQuery
     load_to_bigquery(self.Acct_Level_Summary, self.gcp_project, self.gcp_dataset, "tbl_"+self.output_publish_report+"_balance_sheet", "append")


### PR DESCRIPTION
This PR fixes upload error for tbl_WBR_balance_sheet and tbl_MBR_balance_sheet as a result of the input (Acct_Level_Summary) having duplicate indices.